### PR TITLE
Absolute path names

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,9 +19,9 @@ import (
 	"strings"
 	"time"
 
-	"./config"
-	"./copy"
-	"./messenger"
+	"github.com/dootbin/MCSS/config"
+	"github.com/dootbin/MCSS/copy"
+	"github.com/dootbin/MCSS/messenger"
 	"github.com/jinzhu/now"
 	"github.com/mholt/archiver"
 )


### PR DESCRIPTION
Converted local paths to absolute paths to avoid non-local build/install errors.